### PR TITLE
Fix StringFormat garbled output for 5+ placeholders

### DIFF
--- a/modules/core/src/main/scala/io/taig/babel/StringFormat.scala
+++ b/modules/core/src/main/scala/io/taig/babel/StringFormat.scala
@@ -31,7 +31,7 @@ object StringFormat {
     }
   }
 
-  private[babel] def decoder[A](n: Int)(f: (String, Map[Int, String]) => A): Decoder[A] = Decoder[String].emap {
+  private[babel] def decoder[A](n: Int)(f: (String, List[(Int, String)]) => A): Decoder[A] = Decoder[String].emap {
     (value, path) =>
       val format = parse(value)
       val indices = format.segments.map { case (index, _) => index }
@@ -48,10 +48,10 @@ object StringFormat {
         val offenders = duplicates.mkString(", ")
         val message = s"StringFormat$n may not have duplicate indices, found duplicates for $offenders"
         Left(Decoder.Error(message, path, cause = None))
-      } else Right(f(format.head, format.segments.toMap))
+      } else Right(f(format.head, format.segments))
   }
 
-  private[babel] def build(head: String, segments: Map[Int, String], values: Vector[String]): String = {
+  private[babel] def build(head: String, segments: List[(Int, String)], values: Vector[String]): String = {
     val builder = new StringBuilder(head)
 
     segments.foreach { case (index, segment) =>

--- a/modules/tests/shared/src/test/scala/io/taig/babel/StringFormatTest.scala
+++ b/modules/tests/shared/src/test/scala/io/taig/babel/StringFormatTest.scala
@@ -41,31 +41,31 @@ final class StringFormatTest extends FunSuite {
 
   test("decoder with 5+ placeholders preserves segment order") {
     val format = Decoder[StringFormat6].decode(
-        Babel.Value("a {0} b {1} c {2} d {3} e {4} f {5} g")
+      Babel.Value("a {0} b {1} c {2} d {3} e {4} f {5} g")
     )
     assertEquals(
-        obtained = format.map(_.apply("V0", "V1", "V2", "V3", "V4", "V5")),
-        expected = Right("a V0 b V1 c V2 d V3 e V4 f V5 g")
+      obtained = format.map(_.apply("V0", "V1", "V2", "V3", "V4", "V5")),
+      expected = Right("a V0 b V1 c V2 d V3 e V4 f V5 g")
     )
   }
 
   test("decoder with 5+ placeholders out of order") {
     val format = Decoder[StringFormat6].decode(
-        Babel.Value("{5} a {3} b {1} c {4} d {0} e {2} f")
+      Babel.Value("{5} a {3} b {1} c {4} d {0} e {2} f")
     )
     assertEquals(
-        obtained = format.map(_.apply("V0", "V1", "V2", "V3", "V4", "V5")),
-        expected = Right("V5 a V3 b V1 c V4 d V0 e V2 f")
+      obtained = format.map(_.apply("V0", "V1", "V2", "V3", "V4", "V5")),
+      expected = Right("V5 a V3 b V1 c V4 d V0 e V2 f")
     )
   }
 
   test("decoder with 8 placeholders") {
     val format = Decoder[StringFormat8].decode(
-        Babel.Value("{0}-{1}-{2}-{3}-{4}-{5}-{6}-{7}")
+      Babel.Value("{0}-{1}-{2}-{3}-{4}-{5}-{6}-{7}")
     )
     assertEquals(
-        obtained = format.map(_.apply("a", "b", "c", "d", "e", "f", "g", "h")),
-        expected = Right("a-b-c-d-e-f-g-h")
+      obtained = format.map(_.apply("a", "b", "c", "d", "e", "f", "g", "h")),
+      expected = Right("a-b-c-d-e-f-g-h")
     )
   }
 }

--- a/modules/tests/shared/src/test/scala/io/taig/babel/StringFormatTest.scala
+++ b/modules/tests/shared/src/test/scala/io/taig/babel/StringFormatTest.scala
@@ -38,4 +38,34 @@ final class StringFormatTest extends FunSuite {
   test("decoder has deuplicate placeholders") {
     assert(Decoder[StringFormat2].decode(Babel.Value("lorem {0} dolar {0} amet")).isLeft)
   }
+
+  test("decoder with 5+ placeholders preserves segment order") {
+    val format = Decoder[StringFormat6].decode(
+        Babel.Value("a {0} b {1} c {2} d {3} e {4} f {5} g")
+    )
+    assertEquals(
+        obtained = format.map(_.apply("V0", "V1", "V2", "V3", "V4", "V5")),
+        expected = Right("a V0 b V1 c V2 d V3 e V4 f V5 g")
+    )
+  }
+
+  test("decoder with 5+ placeholders out of order") {
+    val format = Decoder[StringFormat6].decode(
+        Babel.Value("{5} a {3} b {1} c {4} d {0} e {2} f")
+    )
+    assertEquals(
+        obtained = format.map(_.apply("V0", "V1", "V2", "V3", "V4", "V5")),
+        expected = Right("V5 a V3 b V1 c V4 d V0 e V2 f")
+    )
+  }
+
+  test("decoder with 8 placeholders") {
+    val format = Decoder[StringFormat8].decode(
+        Babel.Value("{0}-{1}-{2}-{3}-{4}-{5}-{6}-{7}")
+    )
+    assertEquals(
+        obtained = format.map(_.apply("a", "b", "c", "d", "e", "f", "g", "h")),
+        expected = Right("a-b-c-d-e-f-g-h")
+    )
+  }
 }

--- a/modules/tests/shared/src/test/scala/io/taig/babel/generic/DerivationTest.scala
+++ b/modules/tests/shared/src/test/scala/io/taig/babel/generic/DerivationTest.scala
@@ -16,8 +16,8 @@ final class DerivationTest extends FunSuite {
     val foo: Foo = {
 
       val messages: Quantities[StringFormat1] = {
-        val sfOne: StringFormat1 = (v0: String) => StringFormat.build("You clicked ", Map(0 -> " time"), Vector(v0))
-        val sfMany: StringFormat1 = (v0: String) => StringFormat.build("You clicked ", Map(0 -> " times"), Vector(v0))
+        val sfOne: StringFormat1 = (v0: String) => StringFormat.build("You clicked ", List(0 -> " time"), Vector(v0))
+        val sfMany: StringFormat1 = (v0: String) => StringFormat.build("You clicked ", List(0 -> " times"), Vector(v0))
         Quantities.from[StringFormat1](sfMany, List(Quantities.Element(Quantity.One, sfOne)))
       }
 


### PR DESCRIPTION
# Fix StringFormat garbled output for 5+ placeholders

## Summary

`StringFormat5` through `StringFormat22` produce garbled output because `StringFormat.decoder` converts the parsed segment list to a `Map[Int, String]` via `.toMap`, and `StringFormat.build` iterates that map with `.foreach`. Scala's `HashMap` (used for maps with 5+ entries) does not guarantee iteration order, so the output is scrambled when segments are iterated in hash-bucket order instead of template order.

`StringFormat1` through `StringFormat4` are unaffected because Scala's `Map1`-`Map4` specializations happen to preserve insertion order.

## Fix

Remove the `Map` entirely. The segments are already parsed as an ordered `List[(Int, String)]` by `StringFormat.parse` -- keep them as a `List` throughout. The `Map` was never used for key-based lookup, only for iteration, so it served no purpose.

Both `decoder` and `build` are `private[babel]`, so this is not a public API change.

## Changes

- **`StringFormat.decoder`**: change callback type from `(String, Map[Int, String]) => A` to `(String, List[(Int, String)]) => A`, remove `.toMap` call
- **`StringFormat.build`**: change `segments` parameter type from `Map[Int, String]` to `List[(Int, String)]` (body unchanged)
- **`DerivationTest.scala`**: update two `Map(...)` calls to `List(...)` to match the new signature
- **`StringFormatTest.scala`**: add regression tests with `StringFormat6` and `StringFormat8`

No changes needed in `StringFormats.scala` -- the lambda bodies use type inference and adapt automatically.

## Reproduction

```scala
// Sequential placeholders — before the fix, HashMap iteration scrambles the output
val format = Decoder[StringFormat6].decode(
    Babel.Value("a {0} b {1} c {2} d {3} e {4} f {5} g")
)
format.map(_.apply("V0", "V1", "V2", "V3", "V4", "V5"))
// Expected: Right("a V0 b V1 c V2 d V3 e V4 f V5 g")
// Actual (before fix): garbled — segments appended in hash-bucket order

// Out-of-order placeholders
val format2 = Decoder[StringFormat6].decode(
    Babel.Value("{5} a {3} b {1} c {4} d {0} e {2} f")
)
format2.map(_.apply("V0", "V1", "V2", "V3", "V4", "V5"))
// Expected: Right("V5 a V3 b V1 c V4 d V0 e V2 f")
```
